### PR TITLE
Refactor solid parsers

### DIFF
--- a/src/serializers/solid/pickle_parser.py
+++ b/src/serializers/solid/pickle_parser.py
@@ -4,7 +4,16 @@ Note: Pickle is for Python objects, so this implements JSON parsing
 with Pickle-inspired single-threaded buffering and object reconstruction.
 """
 import json
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass
+class ParserState:
+    """State container for the Pickle parser."""
+
+    buffer: str = ""
+    parsed_data: Dict[str, Any] = field(default_factory=dict)
 
 
 class PairExtractor:
@@ -370,9 +379,20 @@ class StreamingJsonParser:
 
     def __init__(self):
         """Initialize the streaming JSON parser."""
-        self._buffer = ""
-        self._parsed_data = {}
+        self._state = ParserState()
         self._processor = self._create_processor()
+
+    @property
+    def _buffer(self) -> str:
+        return self._state.buffer
+
+    @_buffer.setter
+    def _buffer(self, value: str) -> None:
+        self._state.buffer = value
+
+    @property
+    def _parsed_data(self) -> Dict[str, Any]:
+        return self._state.parsed_data
 
     @staticmethod
     def _create_processor() -> SingleThreadedProcessor:
@@ -405,4 +425,9 @@ class StreamingJsonParser:
         Returns:
             Dictionary containing all complete key-value pairs parsed so far
         """
-        return self._parsed_data.copy()
+        return self._sorted_copy(self._parsed_data)
+
+    @staticmethod
+    def _sorted_copy(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a dict sorted by keys for deterministic output."""
+        return {k: data[k] for k in sorted(data.keys())}


### PR DESCRIPTION
## Summary
- refactor solid parsers using dataclass based state containers
- expose parser state through properties and provide sorted copy helper
- update all `StreamingJsonParser.get` methods to return a sorted dict

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684c036bc404833291c201d5c212cb97