### PR TITLE
Potential fix for code scanning alert no. 109: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ossf-slsa3-publish.yml
+++ b/.github/workflows/ossf-slsa3-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/guillermolam/DeepJudgeStreamingJsonBenchmark/security/code-scanning/109](https://github.com/guillermolam/DeepJudgeStreamingJsonBenchmark/security/code-scanning/109)

To fix the issue, add a `permissions` block to the `build` job in the workflow file. The permissions should be limited to `contents: read`, as the `build` job only needs to read repository contents to perform its tasks. This change adheres to the principle of least privilege and ensures that the job does not inadvertently inherit overly permissive repository settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
