### PR TITLE
Add check_solution utilities to serializers

### DIFF
--- a/src/serializers/__init__.py
+++ b/src/serializers/__init__.py
@@ -1,0 +1,36 @@
+"""Utility helpers for serializer test execution."""
+
+from __future__ import annotations
+
+import inspect
+from types import ModuleType
+from typing import Callable, Iterable, List, Optional
+
+
+def _collect_tests(module: ModuleType) -> List[Callable[[], None]]:
+    """Return zero-argument callables whose names start with ``test_``."""
+    tests: List[Callable[[], None]] = []
+    for name, obj in inspect.getmembers(module):
+        if name.startswith("test_") and callable(obj):
+            try:
+                if not inspect.signature(obj).parameters:
+                    tests.append(obj)
+            except (TypeError, ValueError):
+                # Builtins or callables without a signature
+                continue
+    return tests
+
+
+def run_module_tests(module: ModuleType, tests: Optional[Iterable[Callable[[], None]]] = None) -> bool:
+    """Execute test callables and raise ``RuntimeError`` on failure."""
+    selected_tests = list(tests) if tests is not None else _collect_tests(module)
+    failures: List[str] = []
+    for test in selected_tests:
+        try:
+            test()
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"{test.__name__}: {exc}")
+    if failures:
+        summary = "\n".join(failures)
+        raise RuntimeError(f"Failing tests:\n{summary}")
+    return True

--- a/src/serializers/anyio/bson_parser.py
+++ b/src/serializers/anyio/bson_parser.py
@@ -356,3 +356,9 @@ class StreamingJsonParser:
     async def _get_async(self) -> Dict[str, Any]:
         """Async return current parsed state as a Python object."""
         return {k: self._state.parsed_data[k] for k in sorted(self._state.parsed_data.keys())}
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/cbor_parser.py
+++ b/src/serializers/anyio/cbor_parser.py
@@ -332,3 +332,9 @@ class StreamingJsonParser:
     async def _get_async(self) -> Dict[str, Any]:
         """Async return current parsed state as a Python object."""
         return {k: self._state.parsed_data[k] for k in sorted(self._state.parsed_data.keys())}
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/flatbuffers_parser.py
+++ b/src/serializers/anyio/flatbuffers_parser.py
@@ -219,3 +219,9 @@ class StreamingJsonParser:
     async def _get_async(self) -> Dict[str, Any]:
         """Async return current parsed state as a Python object."""
         return {k: self._state.parsed_data[k] for k in sorted(self._state.parsed_data.keys())}
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/msgpack_parser.py
+++ b/src/serializers/anyio/msgpack_parser.py
@@ -217,3 +217,9 @@ class StreamingJsonParser:
     async def _get_async(self) -> Dict[str, Any]:
         """Async return current parsed state as a Python object."""
         return {k: self._state.parsed_data[k] for k in sorted(self._state.parsed_data.keys())}
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/orjson_parser.py
+++ b/src/serializers/anyio/orjson_parser.py
@@ -217,3 +217,9 @@ class StreamingJsonParser:
     async def _get_async(self) -> Dict[str, Any]:
         """Async return current parsed state as a Python object."""
         return {k: self._state.parsed_data[k] for k in sorted(self._state.parsed_data.keys())}
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/parquet_parser.py
+++ b/src/serializers/anyio/parquet_parser.py
@@ -29,3 +29,9 @@ class StreamingJsonParser(AnyioWrapper):
 
     def get_columnar_data(self) -> Dict[str, Any]:
         return self._parser.get_columnar_data()
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/pickle_parser.py
+++ b/src/serializers/anyio/pickle_parser.py
@@ -494,3 +494,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/protobuf_parser.py
+++ b/src/serializers/anyio/protobuf_parser.py
@@ -492,3 +492,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/anyio/ultrajson_parser.py
+++ b/src/serializers/anyio/ultrajson_parser.py
@@ -489,3 +489,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/bson_parser.py
+++ b/src/serializers/raw/bson_parser.py
@@ -166,3 +166,9 @@ if __name__ == "__main__":
             assert result["outer"].get("inner") == "val"
 
     pytest.main([__file__])
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/cbor_parser.py
+++ b/src/serializers/raw/cbor_parser.py
@@ -339,3 +339,9 @@ class StreamingJsonParser:
             Dictionary containing all complete key-value pairs parsed so far
         """
         return self.parsed_data.copy()
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/flatbuffers_parser.py
+++ b/src/serializers/raw/flatbuffers_parser.py
@@ -184,3 +184,9 @@ class StreamingJsonParser:
                 return tok, i, True
 
         return None, idx, False
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/msgpack_parser.py
+++ b/src/serializers/raw/msgpack_parser.py
@@ -151,3 +151,9 @@ class StreamingJsonParser:
                 return tok, j, True
         # nothing recognized
         return None, i, False
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/parquet_parser.py
+++ b/src/serializers/raw/parquet_parser.py
@@ -189,3 +189,9 @@ class StreamingJsonParser:
 
         # nothing matched
         return None, i, False
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/pickle_parser.py
+++ b/src/serializers/raw/pickle_parser.py
@@ -182,3 +182,9 @@ class StreamingJsonParser:
                 return tok, j, True
 
         return None, idx, False
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/protobuf_parser.py
+++ b/src/serializers/raw/protobuf_parser.py
@@ -203,3 +203,9 @@ class StreamingJsonParser:
             return self._parse_number(s, idx)
         # unrecognized
         return None, idx, False
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/raw/ultrajson_parser.py
+++ b/src/serializers/raw/ultrajson_parser.py
@@ -329,3 +329,9 @@ if __name__ == '__main__':
     test_partial_streaming_json_parser()
 
     print("All tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/bson_parser.py
+++ b/src/serializers/solid/bson_parser.py
@@ -425,3 +425,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/cbor_parser.py
+++ b/src/serializers/solid/cbor_parser.py
@@ -469,3 +469,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/flatbuffers_parser.py
+++ b/src/serializers/solid/flatbuffers_parser.py
@@ -290,3 +290,9 @@ class StreamingJsonParser:
         except ValueError:
             # malformed number → return raw string
             return tok, end_pos, True
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/msgpack_parser.py
+++ b/src/serializers/solid/msgpack_parser.py
@@ -247,3 +247,9 @@ class StreamingJsonParser:
         except ValueError:
             # malformed number treated as raw
             return tok, end_pos, True
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/parquet_parser.py
+++ b/src/serializers/solid/parquet_parser.py
@@ -617,3 +617,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/pickle_parser.py
+++ b/src/serializers/solid/pickle_parser.py
@@ -591,3 +591,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/protobuf_parser.py
+++ b/src/serializers/solid/protobuf_parser.py
@@ -701,3 +701,9 @@ if __name__ == "__main__":
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)

--- a/src/serializers/solid/ultrajson_parser.py
+++ b/src/serializers/solid/ultrajson_parser.py
@@ -601,3 +601,9 @@ if __name__ == '__main__':
     test_chunked_streaming_json_parser()
     test_partial_streaming_json_parser()
     print("Refactored StreamingJsonParser tests passed successfully!")
+
+
+def check_solution(tests=None):
+    from .. import run_module_tests
+    import sys
+    return run_module_tests(sys.modules[__name__], tests)


### PR DESCRIPTION
## Summary
- create `run_module_tests` utility in `src/serializers/__init__.py`
- add `check_solution()` to every serializer implementation

## Testing
- `pyenv local 3.12.10`
- `pip install -e .`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685141bf38588332ad5a57529705330e